### PR TITLE
Simplify packets overriding

### DIFF
--- a/src/Exception/UnknownFlowCodeException.php
+++ b/src/Exception/UnknownFlowCodeException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace BinSoul\Net\Mqtt\Exception;
+
+/**
+ * Will be thrown if a flow code is unknown.
+ */
+class UnknownFlowCodeException extends \Exception
+{
+}

--- a/src/Flow.php
+++ b/src/Flow.php
@@ -7,6 +7,15 @@ namespace BinSoul\Net\Mqtt;
  */
 interface Flow
 {
+    const CODE_PONG = 'pong';
+    const CODE_MESSAGE = 'message';
+    const CODE_CONNECT = 'connect';
+    const CODE_DISCONNECT = 'disconnect';
+    const CODE_PING = 'ping';
+    const CODE_PUBLISH = 'publish';
+    const CODE_SUBSCRIBE = 'subscribe';
+    const CODE_UNSUBSCRIBE = 'unsubscribe';
+
     /**
      * Returns the unique code.
      *

--- a/src/Flow/IncomingPingFlow.php
+++ b/src/Flow/IncomingPingFlow.php
@@ -2,6 +2,7 @@
 
 namespace BinSoul\Net\Mqtt\Flow;
 
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\Packet\PingResponsePacket;
 
 /**
@@ -11,7 +12,7 @@ class IncomingPingFlow extends AbstractFlow
 {
     public function getCode()
     {
-        return 'pong';
+        return Flow::CODE_PONG;
     }
 
     public function start()

--- a/src/Flow/IncomingPublishFlow.php
+++ b/src/Flow/IncomingPublishFlow.php
@@ -2,6 +2,7 @@
 
 namespace BinSoul\Net\Mqtt\Flow;
 
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\Message;
 use BinSoul\Net\Mqtt\Packet;
 use BinSoul\Net\Mqtt\Packet\PublishAckPacket;
@@ -33,7 +34,7 @@ class IncomingPublishFlow extends AbstractFlow
 
     public function getCode()
     {
-        return 'message';
+        return Flow::CODE_MESSAGE;
     }
 
     public function start()

--- a/src/Flow/OutgoingConnectFlow.php
+++ b/src/Flow/OutgoingConnectFlow.php
@@ -3,6 +3,7 @@
 namespace BinSoul\Net\Mqtt\Flow;
 
 use BinSoul\Net\Mqtt\Connection;
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\IdentifierGenerator;
 use BinSoul\Net\Mqtt\Packet;
 use BinSoul\Net\Mqtt\Packet\ConnectRequestPacket;
@@ -33,7 +34,7 @@ class OutgoingConnectFlow extends AbstractFlow
 
     public function getCode()
     {
-        return 'connect';
+        return Flow::CODE_CONNECT;
     }
 
     public function start()

--- a/src/Flow/OutgoingDisconnectFlow.php
+++ b/src/Flow/OutgoingDisconnectFlow.php
@@ -3,6 +3,7 @@
 namespace BinSoul\Net\Mqtt\Flow;
 
 use BinSoul\Net\Mqtt\Connection;
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\Packet\DisconnectRequestPacket;
 
 /**
@@ -25,7 +26,7 @@ class OutgoingDisconnectFlow extends AbstractFlow
 
     public function getCode()
     {
-        return 'disconnect';
+        return Flow::CODE_DISCONNECT;
     }
 
     public function start()

--- a/src/Flow/OutgoingPingFlow.php
+++ b/src/Flow/OutgoingPingFlow.php
@@ -2,6 +2,7 @@
 
 namespace BinSoul\Net\Mqtt\Flow;
 
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\Packet;
 use BinSoul\Net\Mqtt\Packet\PingRequestPacket;
 
@@ -12,7 +13,7 @@ class OutgoingPingFlow extends AbstractFlow
 {
     public function getCode()
     {
-        return 'ping';
+        return Flow::CODE_PING;
     }
 
     public function start()

--- a/src/Flow/OutgoingPublishFlow.php
+++ b/src/Flow/OutgoingPublishFlow.php
@@ -2,6 +2,7 @@
 
 namespace BinSoul\Net\Mqtt\Flow;
 
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\IdentifierGenerator;
 use BinSoul\Net\Mqtt\Message;
 use BinSoul\Net\Mqtt\Packet;
@@ -39,7 +40,7 @@ class OutgoingPublishFlow extends AbstractFlow
 
     public function getCode()
     {
-        return 'publish';
+        return Flow::CODE_PUBLISH;
     }
 
     public function start()

--- a/src/Flow/OutgoingSubscribeFlow.php
+++ b/src/Flow/OutgoingSubscribeFlow.php
@@ -2,6 +2,7 @@
 
 namespace BinSoul\Net\Mqtt\Flow;
 
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\IdentifierGenerator;
 use BinSoul\Net\Mqtt\Packet;
 use BinSoul\Net\Mqtt\Packet\SubscribeRequestPacket;
@@ -32,7 +33,7 @@ class OutgoingSubscribeFlow extends AbstractFlow
 
     public function getCode()
     {
-        return 'subscribe';
+        return Flow::CODE_SUBSCRIBE;
     }
 
     public function start()

--- a/src/Flow/OutgoingUnsubscribeFlow.php
+++ b/src/Flow/OutgoingUnsubscribeFlow.php
@@ -2,6 +2,7 @@
 
 namespace BinSoul\Net\Mqtt\Flow;
 
+use BinSoul\Net\Mqtt\Flow;
 use BinSoul\Net\Mqtt\IdentifierGenerator;
 use BinSoul\Net\Mqtt\Packet;
 use BinSoul\Net\Mqtt\Packet\UnsubscribeRequestPacket;
@@ -32,7 +33,7 @@ class OutgoingUnsubscribeFlow extends AbstractFlow
 
     public function getCode()
     {
-        return 'unsubscribe';
+        return Flow::CODE_UNSUBSCRIBE;
     }
 
     public function start()

--- a/src/FlowFactory.php
+++ b/src/FlowFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace BinSoul\Net\Mqtt;
+
+use BinSoul\Net\Mqtt\Exception\UnknownFlowCodeException;
+
+/**
+ * Builds instances of the {@see Flow} interface.
+ */
+class FlowFactory
+{
+    /**
+     * Map of flow codes to flow classes.
+     *
+     * @var string[]
+     */
+    private $mapping;
+
+    /**
+     * Returns a default flows map.
+     *
+     * @return string[]
+     */
+    public static function getDefaultMapping()
+    {
+        return [
+            Flow::CODE_CONNECT => Flow\OutgoingConnectFlow::class,
+            Flow::CODE_DISCONNECT => Flow\OutgoingDisconnectFlow::class,
+            Flow::CODE_PONG => Flow\IncomingPingFlow::class,
+            Flow::CODE_PING => Flow\OutgoingPingFlow::class,
+            Flow::CODE_PUBLISH => Flow\OutgoingPublishFlow::class,
+            Flow::CODE_MESSAGE => Flow\IncomingPublishFlow::class,
+            Flow::CODE_SUBSCRIBE => Flow\OutgoingSubscribeFlow::class,
+            Flow::CODE_UNSUBSCRIBE => Flow\OutgoingUnsubscribeFlow::class,
+        ];
+    }
+
+    /**
+     * Constructs an instance of this class.
+     *
+     * @param array|null $mapping
+     */
+    public function __construct(array $mapping = null)
+    {
+        if ($mapping === null) {
+            $this->mapping = static::getDefaultMapping();
+        } else {
+            $this->mapping = $mapping;
+        }
+    }
+
+    /**
+     * Builds a flow object for the given code.
+     *
+     * @param string $code
+     * @param array ...$args
+     *
+     * @throws UnknownFlowCodeException
+     *
+     * @return Flow
+     */
+    public function build($code, ...$args)
+    {
+        if (!isset($this->mapping[$code])) {
+            throw new UnknownFlowCodeException(sprintf('Unknown packet code "%s".', $code));
+        }
+
+        $class = $this->mapping[$code];
+
+        return new $class(...$args);
+    }
+}

--- a/src/PacketFactory.php
+++ b/src/PacketFactory.php
@@ -28,22 +28,46 @@ class PacketFactory
      *
      * @var string[]
      */
-    private static $mapping = [
-        Packet::TYPE_CONNECT => ConnectRequestPacket::class,
-        Packet::TYPE_CONNACK => ConnectResponsePacket::class,
-        Packet::TYPE_PUBLISH => PublishRequestPacket::class,
-        Packet::TYPE_PUBACK => PublishAckPacket::class,
-        Packet::TYPE_PUBREC => PublishReceivedPacket::class,
-        Packet::TYPE_PUBREL => PublishReleasePacket::class,
-        Packet::TYPE_PUBCOMP => PublishCompletePacket::class,
-        Packet::TYPE_SUBSCRIBE => SubscribeRequestPacket::class,
-        Packet::TYPE_SUBACK => SubscribeResponsePacket::class,
-        Packet::TYPE_UNSUBSCRIBE => UnsubscribeRequestPacket::class,
-        Packet::TYPE_UNSUBACK => UnsubscribeResponsePacket::class,
-        Packet::TYPE_PINGREQ => PingRequestPacket::class,
-        Packet::TYPE_PINGRESP => PingResponsePacket::class,
-        Packet::TYPE_DISCONNECT => DisconnectRequestPacket::class,
-    ];
+    private $mapping;
+
+    /**
+     * Returns a default packets map.
+     *
+     * @return string[]
+     */
+    public static function getDefaultMapping()
+    {
+        return [
+            Packet::TYPE_CONNECT => ConnectRequestPacket::class,
+            Packet::TYPE_CONNACK => ConnectResponsePacket::class,
+            Packet::TYPE_PUBLISH => PublishRequestPacket::class,
+            Packet::TYPE_PUBACK => PublishAckPacket::class,
+            Packet::TYPE_PUBREC => PublishReceivedPacket::class,
+            Packet::TYPE_PUBREL => PublishReleasePacket::class,
+            Packet::TYPE_PUBCOMP => PublishCompletePacket::class,
+            Packet::TYPE_SUBSCRIBE => SubscribeRequestPacket::class,
+            Packet::TYPE_SUBACK => SubscribeResponsePacket::class,
+            Packet::TYPE_UNSUBSCRIBE => UnsubscribeRequestPacket::class,
+            Packet::TYPE_UNSUBACK => UnsubscribeResponsePacket::class,
+            Packet::TYPE_PINGREQ => PingRequestPacket::class,
+            Packet::TYPE_PINGRESP => PingResponsePacket::class,
+            Packet::TYPE_DISCONNECT => DisconnectRequestPacket::class,
+        ];
+    }
+
+    /**
+     * Constructs an instance of this class.
+     *
+     * @param array|null $mapping
+     */
+    public function __construct(array $mapping = null)
+    {
+        if ($mapping === null) {
+            $this->mapping = static::getDefaultMapping();
+        } else {
+            $this->mapping = $mapping;
+        }
+    }
 
     /**
      * Builds a packet object for the given type.
@@ -56,11 +80,11 @@ class PacketFactory
      */
     public function build($type)
     {
-        if (!isset(self::$mapping[$type])) {
+        if (!isset($this->mapping[$type])) {
             throw new UnknownPacketTypeException(sprintf('Unknown packet type %d.', $type));
         }
 
-        $class = self::$mapping[$type];
+        $class = $this->mapping[$type];
 
         return new $class();
     }

--- a/src/StreamParser.php
+++ b/src/StreamParser.php
@@ -20,11 +20,17 @@ class StreamParser
 
     /**
      * Constructs an instance of this class.
+     *
+     * @param PacketFactory|null $factory
      */
-    public function __construct()
+    public function __construct(PacketFactory $factory = null)
     {
+        if ($factory !== null) {
+            $this->factory = $factory;
+        } else {
+            $this->factory = new PacketFactory();
+        }
         $this->buffer = new PacketStream();
-        $this->factory = new PacketFactory();
     }
 
     /**

--- a/tests/Flow/FlowFactoryTest.php
+++ b/tests/Flow/FlowFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace BinSoul\Test\Net\Mqtt\Flow;
+
+use BinSoul\Net\Mqtt\DefaultConnection;
+use BinSoul\Net\Mqtt\DefaultIdentifierGenerator;
+use BinSoul\Net\Mqtt\DefaultMessage;
+use BinSoul\Net\Mqtt\Exception\UnknownFlowCodeException;
+use BinSoul\Net\Mqtt\Flow;
+use BinSoul\Net\Mqtt\FlowFactory;
+
+class FlowFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    function test_default_flows()
+    {
+        $factory = new FlowFactory();
+
+        $incomingPingFlow = $factory->build(Flow::CODE_PONG);
+        $this->assertInstanceOf(Flow\IncomingPingFlow::class, $incomingPingFlow);
+
+        $incomingPublishFlow = $factory->build(Flow::CODE_MESSAGE, new DefaultMessage('foo'));
+        $this->assertInstanceOf(Flow\IncomingPublishFlow::class, $incomingPublishFlow);
+
+        $outgoingConnectFlow = $factory->build(Flow::CODE_CONNECT, new DefaultConnection(), new DefaultIdentifierGenerator());
+        $this->assertInstanceOf(Flow\OutgoingConnectFlow::class, $outgoingConnectFlow);
+
+        $outgoingDisconnectFlow = $factory->build(Flow::CODE_DISCONNECT, new DefaultConnection());
+        $this->assertInstanceOf(Flow\OutgoingDisconnectFlow::class, $outgoingDisconnectFlow);
+
+        $outgoingPingFlow = $factory->build(Flow::CODE_PING);
+        $this->assertInstanceOf(Flow\OutgoingPingFlow::class, $outgoingPingFlow);
+
+        $outgoingPublishFlow = $factory->build(Flow::CODE_PUBLISH, new DefaultMessage('foo'), new DefaultIdentifierGenerator());
+        $this->assertInstanceOf(Flow\OutgoingPublishFlow::class, $outgoingPublishFlow);
+
+        $outgoingSubscribeFlow = $factory->build(Flow::CODE_SUBSCRIBE, ['foo'], new DefaultIdentifierGenerator());
+        $this->assertInstanceOf(Flow\OutgoingSubscribeFlow::class, $outgoingSubscribeFlow);
+
+        $outgoingUnsubscribeFlow = $factory->build(Flow::CODE_UNSUBSCRIBE, ['foo'], new DefaultIdentifierGenerator());
+        $this->assertInstanceOf(Flow\OutgoingUnsubscribeFlow::class, $outgoingUnsubscribeFlow);
+    }
+
+    function test_unknown_code()
+    {
+        $factory = new FlowFactory();
+
+        $this->expectException(UnknownFlowCodeException::class);
+        $factory->build('unknown');
+    }
+
+    function test_mapping_override()
+    {
+        $factory = new FlowFactory(array_merge(FlowFactory::getDefaultMapping(), [
+            Flow::CODE_PING => Flow\IncomingPingFlow::class,
+        ]));
+
+        $outgoingPingFlow = $factory->build(Flow::CODE_PING);
+        $this->assertInstanceOf(Flow\IncomingPingFlow::class, $outgoingPingFlow);
+    }
+}

--- a/tests/Packet/PacketFactoryTest.php
+++ b/tests/Packet/PacketFactoryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace BinSoul\Test\Net\Mqtt\Packet;
+
+use BinSoul\Net\Mqtt\Exception\UnknownPacketTypeException;
+use BinSoul\Net\Mqtt\PacketFactory;
+use BinSoul\Net\Mqtt\Packet;
+
+class PacketFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    function test_default_packets()
+    {
+        $factory = new PacketFactory();
+
+        $connectRequestPacket = $factory->build(Packet::TYPE_CONNECT);
+        $this->assertInstanceOf(Packet\ConnectRequestPacket::class, $connectRequestPacket);
+
+        $connectResponsePacket = $factory->build(Packet::TYPE_CONNACK);
+        $this->assertInstanceOf(Packet\ConnectResponsePacket::class, $connectResponsePacket);
+
+        $disconnectRequestPacket = $factory->build(Packet::TYPE_DISCONNECT);
+        $this->assertInstanceOf(Packet\DisconnectRequestPacket::class, $disconnectRequestPacket);
+
+        $pingRequestPacket = $factory->build(Packet::TYPE_PINGREQ);
+        $this->assertInstanceOf(Packet\PingRequestPacket::class, $pingRequestPacket);
+
+        $pingResponsePacket = $factory->build(Packet::TYPE_PINGRESP);
+        $this->assertInstanceOf(Packet\PingResponsePacket::class, $pingResponsePacket);
+
+        $publishAckPacket = $factory->build(Packet::TYPE_PUBACK);
+        $this->assertInstanceOf(Packet\PublishAckPacket::class, $publishAckPacket);
+
+        $publishCompletePacket = $factory->build(Packet::TYPE_PUBCOMP);
+        $this->assertInstanceOf(Packet\PublishCompletePacket::class, $publishCompletePacket);
+
+        $publishReceivedPacket = $factory->build(Packet::TYPE_PUBREC);
+        $this->assertInstanceOf(Packet\PublishReceivedPacket::class, $publishReceivedPacket);
+
+        $publishReleasePacket = $factory->build(Packet::TYPE_PUBREL);
+        $this->assertInstanceOf(Packet\PublishReleasePacket::class, $publishReleasePacket);
+
+        $publishRequestPacket = $factory->build(Packet::TYPE_PUBLISH);
+        $this->assertInstanceOf(Packet\PublishRequestPacket::class, $publishRequestPacket);
+
+        $subscribeRequestPacket = $factory->build(Packet::TYPE_SUBSCRIBE);
+        $this->assertInstanceOf(Packet\SubscribeRequestPacket::class, $subscribeRequestPacket);
+
+        $subscribeResponsePacket = $factory->build(Packet::TYPE_SUBACK);
+        $this->assertInstanceOf(Packet\SubscribeResponsePacket::class, $subscribeResponsePacket);
+
+        $unsubscribeRequestPacket = $factory->build(Packet::TYPE_UNSUBSCRIBE);
+        $this->assertInstanceOf(Packet\UnsubscribeRequestPacket::class, $unsubscribeRequestPacket);
+
+        $unsubscribeResponsePacket = $factory->build(Packet::TYPE_UNSUBACK);
+        $this->assertInstanceOf(Packet\UnsubscribeResponsePacket::class, $unsubscribeResponsePacket);
+    }
+
+    function test_unknown_type()
+    {
+        $factory = new PacketFactory();
+
+        $this->expectException(UnknownPacketTypeException::class);
+        $factory->build('unknown');
+    }
+
+    function test_mapping_override()
+    {
+        $factory = new PacketFactory([
+            Packet::TYPE_CONNECT => Packet\StrictConnectRequestPacket::class,
+        ] + PacketFactory::getDefaultMapping());
+
+        $connectRequestPacket = $factory->build(Packet::TYPE_CONNECT);
+        $this->assertInstanceOf(Packet\StrictConnectRequestPacket::class, $connectRequestPacket);
+    }
+}


### PR DESCRIPTION
This PR:
1. Simplifies overriding incoming packets by allowing to pass `PacketFactory` with custom mapping to `StreamParser` constructor. So you can do something like this:
```php
$streamParser = new StreamParser(new PacketFactory([
    Packet::TYPE_PUBACK => CustomPublishAckPacket::class,
    Packet::TYPE_CONNACK => CustomConnectResponsePacket::class,
] + PacketFactory::getDefaultMapping()));
$client = ReactMqttClient($connector, $loop, null, $streamParser);
```
2. Adds `FlowFactory` class for building flows by code with an ability to override certain flows. This is useful for sending custom outgoing packets and will be used in `net-mqtt-client-react`.