### PR TITLE
Use Flow as return type in FlowFactory methods

### DIFF
--- a/src/DefaultFlowFactory.php
+++ b/src/DefaultFlowFactory.php
@@ -48,42 +48,42 @@ class DefaultFlowFactory implements FlowFactory
         $this->packetFactory = $packetFactory;
     }
 
-    public function buildIncomingPingFlow(): IncomingPingFlow
+    public function buildIncomingPingFlow(): Flow
     {
         return new IncomingPingFlow($this->packetFactory);
     }
 
-    public function buildIncomingPublishFlow(Message $message, int $identifier = null): IncomingPublishFlow
+    public function buildIncomingPublishFlow(Message $message, int $identifier = null): Flow
     {
         return new IncomingPublishFlow($this->packetFactory, $message, $identifier);
     }
 
-    public function buildOutgoingConnectFlow(Connection $connection): OutgoingConnectFlow
+    public function buildOutgoingConnectFlow(Connection $connection): Flow
     {
         return new OutgoingConnectFlow($this->packetFactory, $connection, $this->clientIdentifierGenerator);
     }
 
-    public function buildOutgoingDisconnectFlow(Connection $connection): OutgoingDisconnectFlow
+    public function buildOutgoingDisconnectFlow(Connection $connection): Flow
     {
         return new OutgoingDisconnectFlow($this->packetFactory, $connection);
     }
 
-    public function buildOutgoingPingFlow(): OutgoingPingFlow
+    public function buildOutgoingPingFlow(): Flow
     {
         return new OutgoingPingFlow($this->packetFactory);
     }
 
-    public function buildOutgoingPublishFlow(Message $message): OutgoingPublishFlow
+    public function buildOutgoingPublishFlow(Message $message): Flow
     {
         return new OutgoingPublishFlow($this->packetFactory, $message, $this->packetIdentifierGenerator);
     }
 
-    public function buildOutgoingSubscribeFlow(array $subscriptions): OutgoingSubscribeFlow
+    public function buildOutgoingSubscribeFlow(array $subscriptions): Flow
     {
         return new OutgoingSubscribeFlow($this->packetFactory, $subscriptions, $this->packetIdentifierGenerator);
     }
 
-    public function buildOutgoingUnsubscribeFlow(array $subscriptions): OutgoingUnsubscribeFlow
+    public function buildOutgoingUnsubscribeFlow(array $subscriptions): Flow
     {
         return new OutgoingUnsubscribeFlow($this->packetFactory, $subscriptions, $this->packetIdentifierGenerator);
     }

--- a/src/FlowFactory.php
+++ b/src/FlowFactory.php
@@ -4,14 +4,7 @@ declare(strict_types=1);
 
 namespace BinSoul\Net\Mqtt;
 
-use BinSoul\Net\Mqtt\Flow\IncomingPingFlow;
-use BinSoul\Net\Mqtt\Flow\IncomingPublishFlow;
-use BinSoul\Net\Mqtt\Flow\OutgoingConnectFlow;
-use BinSoul\Net\Mqtt\Flow\OutgoingDisconnectFlow;
-use BinSoul\Net\Mqtt\Flow\OutgoingPingFlow;
-use BinSoul\Net\Mqtt\Flow\OutgoingPublishFlow;
-use BinSoul\Net\Mqtt\Flow\OutgoingSubscribeFlow;
-use BinSoul\Net\Mqtt\Flow\OutgoingUnsubscribeFlow;
+use BinSoul\Net\Mqtt\Flow;
 
 /**
  * Builds instances of the {@see Flow} interface.
@@ -19,55 +12,55 @@ use BinSoul\Net\Mqtt\Flow\OutgoingUnsubscribeFlow;
 interface FlowFactory
 {
     /**
-     * @return IncomingPingFlow
+     * @return Flow
      */
-    public function buildIncomingPingFlow(): IncomingPingFlow;
+    public function buildIncomingPingFlow(): Flow;
 
     /**
      * @param Message  $message
      * @param int|null $identifier
      *
-     * @return IncomingPublishFlow
+     * @return Flow
      */
-    public function buildIncomingPublishFlow(Message $message, int $identifier = null): IncomingPublishFlow;
+    public function buildIncomingPublishFlow(Message $message, int $identifier = null): Flow;
 
     /**
      * @param Connection $connection
      *
-     * @return OutgoingConnectFlow
+     * @return Flow
      */
-    public function buildOutgoingConnectFlow(Connection $connection): OutgoingConnectFlow;
+    public function buildOutgoingConnectFlow(Connection $connection): Flow;
 
     /**
      * @param Connection $connection
      *
-     * @return OutgoingDisconnectFlow
+     * @return Flow
      */
-    public function buildOutgoingDisconnectFlow(Connection $connection): OutgoingDisconnectFlow;
+    public function buildOutgoingDisconnectFlow(Connection $connection): Flow;
 
     /**
-     * @return OutgoingPingFlow
+     * @return Flow
      */
-    public function buildOutgoingPingFlow(): OutgoingPingFlow;
+    public function buildOutgoingPingFlow(): Flow;
 
     /**
      * @param Message $message
      *
-     * @return OutgoingPublishFlow
+     * @return Flow
      */
-    public function buildOutgoingPublishFlow(Message $message): OutgoingPublishFlow;
+    public function buildOutgoingPublishFlow(Message $message): Flow;
 
     /**
      * @param Subscription[] $subscriptions
      *
-     * @return OutgoingSubscribeFlow
+     * @return Flow
      */
-    public function buildOutgoingSubscribeFlow(array $subscriptions): OutgoingSubscribeFlow;
+    public function buildOutgoingSubscribeFlow(array $subscriptions): Flow;
 
     /**
      * @param Subscription[] $subscriptions
      *
-     * @return OutgoingUnsubscribeFlow
+     * @return Flow
      */
-    public function buildOutgoingUnsubscribeFlow(array $subscriptions): OutgoingUnsubscribeFlow;
+    public function buildOutgoingUnsubscribeFlow(array $subscriptions): Flow;
 }


### PR DESCRIPTION
It's impossible to create custom flow factories, because covariant returns have been added only in PHP 7.4.

This PR fixes that omission.