### PR TITLE
Support multiple subscriptions

### DIFF
--- a/src/Flow/OutgoingSubscribeFlow.php
+++ b/src/Flow/OutgoingSubscribeFlow.php
@@ -45,9 +45,11 @@ class OutgoingSubscribeFlow extends AbstractFlow
     {
         /** @var SubscribeRequestPacket $packet */
         $packet = $this->generatePacket(Packet::TYPE_SUBSCRIBE);
-        $packet->setTopic($this->subscriptions[0]->getFilter());
-        $packet->setQosLevel($this->subscriptions[0]->getQosLevel());
         $packet->setIdentifier($this->identifier);
+
+        foreach ($this->subscriptions as $subscription) {
+            $packet->addTopic($subscription->getFilter(), $subscription->getQosLevel());
+        }
 
         return $packet;
     }
@@ -93,7 +95,7 @@ class OutgoingSubscribeFlow extends AbstractFlow
             }
         }
 
-        $this->succeed($this->subscriptions[0]);
+        $this->succeed(count($this->subscriptions) === 1 ? $this->subscriptions[0] : $this->subscriptions);
 
         return null;
     }

--- a/src/Packet/SubscribeRequestPacket.php
+++ b/src/Packet/SubscribeRequestPacket.php
@@ -25,10 +25,13 @@ class SubscribeRequestPacket extends BasePacket
     public function read(PacketStream $stream): void
     {
         parent::read($stream);
+
         $this->assertPacketFlags(2);
         $this->assertRemainingPacketLength();
+
         $originalPosition = $stream->getPosition();
         $this->identifier = $stream->readWord();
+        $this->topics = [];
 
         do {
             $topic = $stream->readString();

--- a/src/Packet/SubscribeRequestPacket.php
+++ b/src/Packet/SubscribeRequestPacket.php
@@ -27,9 +27,10 @@ class SubscribeRequestPacket extends BasePacket
         parent::read($stream);
         $this->assertPacketFlags(2);
         $this->assertRemainingPacketLength();
+        $originalPosition = $stream->getPosition();
         $this->identifier = $stream->readWord();
 
-        while ($stream->getRemainingBytes() > 0) {
+        do {
             $topic = $stream->readString();
             $qosLevel = $stream->readByte();
 
@@ -37,7 +38,7 @@ class SubscribeRequestPacket extends BasePacket
             $this->assertValidQosLevel($qosLevel);
 
             $this->topics[$topic] = $qosLevel;
-        }
+        } while (($stream->getPosition() - $originalPosition) < $this->remainingPacketLength);
     }
 
     public function write(PacketStream $stream): void

--- a/tests/Packet/SubscribeRequestPacketTest.php
+++ b/tests/Packet/SubscribeRequestPacketTest.php
@@ -17,17 +17,19 @@ class SubscribeRequestPacketTest extends TestCase
         return "\x82\x06\x00\x01\x00\x01#\x00";
     }
 
+    private function getMultipleTopicsData(): string
+    {
+        return "\x82\x0D\x00\x01\x00\x01#\x00\x00\x04test\x01";
+    }
+
     public function test_getters_and_setters(): void
     {
         $packet = new SubscribeRequestPacket();
         $packet->setIdentifier(1);
         $this->assertEquals(1, $packet->getIdentifier());
 
-        $packet->setTopic('#');
-        $this->assertEquals('#', $packet->getTopic());
-
-        $packet->setQosLevel(1);
-        $this->assertEquals(1, $packet->getQosLevel());
+        $packet->addTopic('#', 1);
+        $this->assertEquals(['#' => 1], $packet->getTopics());
     }
 
     public function test_cannot_set_negative_identifier(): void
@@ -48,29 +50,28 @@ class SubscribeRequestPacketTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $packet = new SubscribeRequestPacket();
-        $packet->setTopic('');
+        $packet->addTopic('', 0);
     }
 
     public function test_cannot_set_too_large_topic(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $packet = new SubscribeRequestPacket();
-        $packet->setTopic(str_repeat('x', 0x10000));
+        $packet->addTopic(str_repeat('x', 0x10000), 0);
     }
 
     public function test_cannot_set_invalid_qos_level(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $packet = new SubscribeRequestPacket();
-        $packet->setQosLevel(10);
+        $packet->addTopic('#', 10);
     }
 
     public function test_write(): void
     {
         $packet = new SubscribeRequestPacket();
         $packet->setIdentifier(1);
-        $packet->setTopic('#');
-        $packet->setQosLevel(0);
+        $packet->addTopic('#', 0);
 
         $stream = new PacketStream();
         $packet->write($stream);
@@ -91,8 +92,7 @@ class SubscribeRequestPacketTest extends TestCase
     {
         $packet = new SubscribeRequestPacket();
         $packet->setIdentifier(1);
-        $packet->setTopic('#');
-        $packet->setQosLevel(0);
+        $packet->addTopic('#', 0);
 
         $stream = new PacketStream();
         $packet->write($stream);
@@ -101,5 +101,43 @@ class SubscribeRequestPacketTest extends TestCase
         $packet = new SubscribeRequestPacket();
         $packet->read($stream);
         $this->assertEquals($this->getDefaultData(), $stream->getData());
+    }
+
+    public function test_write_with_multiple_topics(): void
+    {
+        $packet = new SubscribeRequestPacket();
+        $packet->setIdentifier(1);
+        $packet->addTopic('#', 0);
+        $packet->addTopic('test', 1);
+
+        $stream = new PacketStream();
+        $packet->write($stream);
+
+        $this->assertEquals($this->getMultipleTopicsData(), $stream->getData());
+    }
+
+    public function test_read_with_multiple_topics(): void
+    {
+        $stream = new PacketStream($this->getMultipleTopicsData());
+        $packet = new SubscribeRequestPacket();
+        $packet->read($stream);
+
+        $this->assertEquals(Packet::TYPE_SUBSCRIBE, $packet->getPacketType());
+    }
+
+    public function test_can_read_what_it_writes_with_multiple_topics(): void
+    {
+        $packet = new SubscribeRequestPacket();
+        $packet->setIdentifier(1);
+        $packet->addTopic('#', 0);
+        $packet->addTopic('test', 1);
+
+        $stream = new PacketStream();
+        $packet->write($stream);
+        $stream->setPosition(0);
+
+        $packet = new SubscribeRequestPacket();
+        $packet->read($stream);
+        $this->assertEquals($this->getMultipleTopicsData(), $stream->getData());
     }
 }


### PR DESCRIPTION
This patch adds support for multiple subscriptions with a single packet.

I don't know why it was previously limited to a single subscription per packet but I didn't find any reason for not supporting multiple subscriptions with a single packet.
I tried to be BC which is the reason why the Flow uses a single subscription for the result when there is just one subscription and the array of subscriptions when there are more.
This shouldn't break BC for the client.

However, in case of someone using this library directly, especially the `SubscribeRequestPacket` class and is not using the `OutgoingSubscribeFlow`, this patch breaks BC. I don't know how important this is.