### PR TITLE
OutgoingConnectFlow: allow empty Will Message

### DIFF
--- a/src/Flow/OutgoingConnectFlow.php
+++ b/src/Flow/OutgoingConnectFlow.php
@@ -49,7 +49,7 @@ class OutgoingConnectFlow extends AbstractFlow
         $packet->setUsername($this->connection->getUsername());
         $packet->setPassword($this->connection->getPassword());
         $will = $this->connection->getWill();
-        if ($will !== null && $will->getTopic() !== '' && $will->getPayload() !== '') {
+        if ($will !== null && $will->getTopic() !== '') {
             $packet->setWill($will->getTopic(), $will->getPayload(), $will->getQosLevel(), $will->isRetained());
         }
 


### PR DESCRIPTION
It should be possible to publish a blank message with the retain flag set to true which clears the retained message set at another time.