### PR TITLE
No descriptive error is thrown when wildcards present in a publish topic

### DIFF
--- a/src/Packet/PublishRequestPacket.php
+++ b/src/Packet/PublishRequestPacket.php
@@ -77,6 +77,9 @@ class PublishRequestPacket extends BasePacket
         if ($value === '') {
             throw new InvalidArgumentException('The topic must not be empty.');
         }
+        if (strpbrk($value, '+#')) {
+            throw new InvalidArgumentException('The topic must not contain wildcards.');
+        }
 
         try {
             $this->assertValidString($value);

--- a/tests/Packet/PublishRequestPacketTest.php
+++ b/tests/Packet/PublishRequestPacketTest.php
@@ -75,6 +75,20 @@ class PublishRequestPacketTest extends TestCase
         $packet->setTopic(str_repeat('x', 0x10000));
     }
 
+    public function test_cannot_set_single_level_wildcard_topic(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $packet = new PublishRequestPacket();
+        $packet->setTopic('topic/+');
+    }
+
+    public function test_cannot_set_multi_level_wildcard_topic(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $packet = new PublishRequestPacket();
+        $packet->setTopic('#');
+    }
+
     public function test_cannot_set_negative_qos_level(): void
     {
         $this->expectException(InvalidArgumentException::class);


### PR DESCRIPTION
When publishing a message (e.g. using binsoul/net-mqtt-react), topic validity is not checked against MQTT wildcards, and a very unrelated Error is thrown in:

`Error: Value of type null is not callable in .../vendor/react/async/src/SimpleFiber.php:74`

With this update a more descriptive Error (InvalidArgumentException) is thrown.